### PR TITLE
Allow H5 data to be sent with msgpack

### DIFF
--- a/girder/stemserver_plugin/models/stemimage.py
+++ b/girder/stemserver_plugin/models/stemimage.py
@@ -107,7 +107,7 @@ class StemImage(AccessControlledModel):
     def _get_h5_dataset(self, id, user, path, format='bytes'):
         f = self._get_file(id, user)
 
-        if format == 'bytes':
+        if format == 'bytes' or format is None:
             return self._get_h5_dataset_bytes(f, path)
         elif format == 'msgpack':
             return self._get_h5_dataset_msgpack(f, path)

--- a/girder/stemserver_plugin/models/stemimage.py
+++ b/girder/stemserver_plugin/models/stemimage.py
@@ -254,5 +254,11 @@ class StemImage(AccessControlledModel):
 
         Returns: a dataset packed with msgpack
         """
-        with h5py.File(f, 'r') as rf:
-            return msgpack.packb(rf[path][()].tolist(), use_bin_type=True)
+        setResponseHeader('Content-Type', 'application/octet-stream')
+
+        def _stream():
+            nonlocal f
+            with h5py.File(f, 'r') as rf:
+                yield msgpack.packb(rf[path][()].tolist(), use_bin_type=True)
+
+        return _stream

--- a/girder/stemserver_plugin/stemimage.py
+++ b/girder/stemserver_plugin/stemimage.py
@@ -47,17 +47,25 @@ class StemImage(Resource):
     @autoDescribeRoute(
         Description('Get the bright field of a stem image.')
         .param('id', 'The id of the stem image.')
+        .param('format',
+               'The format with which to send the data over http. '
+               'Currently either bytes (default) or msgpack.',
+               required=False)
     )
-    def bright(self, id):
-        return self._model.bright(id, getCurrentUser())
+    def bright(self, id, format=None):
+        return self._model.bright(id, format, getCurrentUser())
 
     @access.user
     @autoDescribeRoute(
         Description('Get the dark field of a stem image.')
         .param('id', 'The id of the stem image.')
+        .param('format',
+               'The format with which to send the data over http. '
+               'Currently either bytes (default) or msgpack',
+               required=False)
     )
-    def dark(self, id):
-        return self._model.dark(id, getCurrentUser())
+    def dark(self, id, format=None):
+        return self._model.dark(id, format, getCurrentUser())
 
     @access.user
     @autoDescribeRoute(

--- a/girder/stemserver_plugin/stemimage.py
+++ b/girder/stemserver_plugin/stemimage.py
@@ -54,7 +54,7 @@ class StemImage(Resource):
                'Currently either bytes (default) or msgpack.',
                required=False)
     )
-    def bright(self, id, format=None):
+    def bright(self, id, format):
         return self._model.bright(id, getCurrentUser(), format)
 
     @access.user
@@ -66,7 +66,7 @@ class StemImage(Resource):
                'Currently either bytes (default) or msgpack',
                required=False)
     )
-    def dark(self, id, format=None):
+    def dark(self, id, format):
         return self._model.dark(id, getCurrentUser(), format)
 
     @access.user

--- a/girder/stemserver_plugin/stemimage.py
+++ b/girder/stemserver_plugin/stemimage.py
@@ -55,7 +55,7 @@ class StemImage(Resource):
                required=False)
     )
     def bright(self, id, format=None):
-        return self._model.bright(id, format, getCurrentUser())
+        return self._model.bright(id, getCurrentUser(), format)
 
     @access.user
     @autoDescribeRoute(
@@ -67,7 +67,7 @@ class StemImage(Resource):
                required=False)
     )
     def dark(self, id, format=None):
-        return self._model.dark(id, format, getCurrentUser())
+        return self._model.dark(id, getCurrentUser(), format)
 
     @access.user
     @autoDescribeRoute(
@@ -87,7 +87,7 @@ class StemImage(Resource):
 
     @access.user
     @autoDescribeRoute(
-        Description('Get a frame of an image (in bytes).')
+        Description('Get a frame of an image.')
         .param('id', 'The id of the stem image.')
         .param('scan_position', 'The scan position of the frame.',
                dataType='integer')
@@ -98,7 +98,7 @@ class StemImage(Resource):
 
     @access.user
     @autoDescribeRoute(
-        Description('Get all frames of an image (in msgpack format).')
+        Description('Get all frames of an image (msgpack format only).')
         .param('id', 'The id of the stem image.')
     )
     def all_frames(self, id):
@@ -114,7 +114,7 @@ class StemImage(Resource):
 
     @access.user
     @autoDescribeRoute(
-        Description('Get the scan positions of an image (in bytes).')
+        Description('Get the scan positions of an image.')
         .param('id', 'The id of the stem image.')
     )
     def scan_positions(self, id):


### PR DESCRIPTION
This is a basic start for using `msgpack` in our plugin.

I think this PR can also be a place where we discuss:

1. Should we use `msgpack`? 
2. If yes, how should we use it?

One issue I currently see is that msgpack doesn't have a native way to serialize/deserialize numpy arrays. And, as far as I know, h5py always returns numpy arrays. One option is that we can convert the numpy arrays to lists and then pack them with msgpack, but this will incur an extra copy operation. We could also use a tool [like this one](https://github.com/lebedov/msgpack-numpy) to get msgpack to serialize numpy arrays, but then we may need to have tools like that on both the server and client sides.

We can also discuss if we should use any encodings/optimizations like [mmtf does](https://github.com/rcsb/mmtf/blob/v1.0/spec.md#encodings) in order to make the data transfer more efficient. I think it's possible for us to do the encodings with/without `msgpack`.

(Also, currently, the entire dataset is sent at once over http. There may be room for improvement by `yield`ing)

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>