### PR TITLE
Add endpoints for electron event frames and scans

### DIFF
--- a/girder/setup.py
+++ b/girder/setup.py
@@ -9,7 +9,8 @@ with open('README.rst') as readme_file:
 requirements = [
     'girder>=3.0.0a1',
     'h5py>=2.9.0',
-    'numpy>=1.7'
+    'numpy>=1.7',
+    'msgpack>=0.6.1'
 ]
 
 setup(

--- a/girder/stemserver_plugin/models/stemimage.py
+++ b/girder/stemserver_plugin/models/stemimage.py
@@ -190,13 +190,13 @@ class StemImage(AccessControlledModel):
 
         return _stream
 
-    def detector_positions(self, id, user):
+    def detector_dimensions(self, id, user):
         f = self._get_file(id, user)
         path = '/electron_events/frames'
         with h5py.File(f, 'r') as rf:
             dataset = rf[path]
             if 'Nx' not in dataset.attrs or 'Ny' not in dataset.attrs:
-                raise RestException('Detector positions not found!', 404)
+                raise RestException('Detector dimensions not found!', 404)
 
             return int(dataset.attrs['Nx']), int(dataset.attrs['Ny'])
 

--- a/girder/stemserver_plugin/models/stemimage.py
+++ b/girder/stemserver_plugin/models/stemimage.py
@@ -198,7 +198,7 @@ class StemImage(AccessControlledModel):
             if 'Nx' not in dataset.attrs or 'Ny' not in dataset.attrs:
                 raise RestException('Detector positions not found!', 404)
 
-            return dataset.attrs['Nx'], dataset.attrs['Ny']
+            return int(dataset.attrs['Nx']), int(dataset.attrs['Ny'])
 
     def scan_positions(self, id, user):
         return self._get_h5_dataset(id, user,

--- a/girder/stemserver_plugin/models/stemimage.py
+++ b/girder/stemserver_plugin/models/stemimage.py
@@ -130,3 +130,10 @@ class StemImage(AccessControlledModel):
 
     def dark_shape(self, id, user):
         return self._get_h5_dataset_shape(id, user, '/stem/dark')
+
+    def electron_frames(self, id, user):
+        return self._get_h5_dataset(id, user, '/electron_events/frames')
+
+    def electron_scans(self, id, user):
+        return self._get_h5_dataset(id, user,
+                                    '/electron_events/scan_positions')

--- a/girder/stemserver_plugin/models/stemimage.py
+++ b/girder/stemserver_plugin/models/stemimage.py
@@ -41,7 +41,7 @@ class StemImage(AccessControlledModel):
         if 'fileId' in doc:
             FileModel().load(doc['fileId'], level=AccessType.READ, force=True)
         else:
-            raise RestException('stem image must contain `fileId`', code=400)
+            raise RestException('stem image must contain `fileId`')
 
         return doc
 
@@ -53,8 +53,7 @@ class StemImage(AccessControlledModel):
             # Only admin users can do this
             admin = user.get('admin', False)
             if admin is not True:
-                raise RestException('Only admin users can use a filePath',
-                                    code=403)
+                raise RestException('Only admin users can use a filePath', 403)
 
             name = os.path.basename(file_path)
             item = self._create_import_item(user, name)
@@ -64,8 +63,7 @@ class StemImage(AccessControlledModel):
             f = adapter.importFile(item, file_path, user)
             stem_image['fileId'] = f['_id']
         else:
-            raise RestException('Must set either fileId or filePath',
-                                code=400)
+            raise RestException('Must set either fileId or filePath')
 
         self.setUserAccess(stem_image, user=user, level=AccessType.ADMIN)
         if public:
@@ -77,7 +75,7 @@ class StemImage(AccessControlledModel):
         stem_image = self.load(id, user=user, level=AccessType.WRITE)
 
         if not stem_image:
-            raise RestException('StemImage not found.', code=404)
+            raise RestException('StemImage not found.', 404)
 
         # Try to load the file and check if it was imported.
         # If it was imported, delete the item containing the file.
@@ -100,7 +98,7 @@ class StemImage(AccessControlledModel):
         stem_image = self.load(stem_image_id, user=user, level=AccessType.READ)
 
         if not stem_image:
-            raise RestException('StemImage not found.', code=404)
+            raise RestException('StemImage not found.', 404)
 
         girder_file = FileModel().load(stem_image['fileId'],
                                        level=AccessType.READ, user=user)
@@ -218,6 +216,5 @@ class StemImage(AccessControlledModel):
         """Gets the asset store and ensures it is a file system"""
         assetstore = AssetstoreModel().getCurrent()
         if assetstore['type'] is not AssetstoreType.FILESYSTEM:
-            raise RestException('Current assetstore is not a file system!',
-                                code=400)
+            raise RestException('Current assetstore is not a file system!')
         return assetstore

--- a/girder/stemserver_plugin/models/stemimage.py
+++ b/girder/stemserver_plugin/models/stemimage.py
@@ -190,6 +190,16 @@ class StemImage(AccessControlledModel):
 
         return _stream
 
+    def detector_positions(self, id, user):
+        f = self._get_file(id, user)
+        path = '/electron_events/frames'
+        with h5py.File(f, 'r') as rf:
+            dataset = rf[path]
+            if 'Nx' not in dataset.attrs or 'Ny' not in dataset.attrs:
+                raise RestException('Detector positions not found!', 404)
+
+            return dataset.attrs['Nx'], dataset.attrs['Ny']
+
     def scan_positions(self, id, user):
         return self._get_h5_dataset(id, user,
                                     '/electron_events/scan_positions')

--- a/girder/stemserver_plugin/stemimage.py
+++ b/girder/stemserver_plugin/stemimage.py
@@ -20,6 +20,8 @@ class StemImage(Resource):
         self.route('GET', (':id', 'dark', 'shape'), self.dark_shape)
         self.route('GET', (':id', 'frames', ':scan_position'), self.frame)
         self.route('GET', (':id', 'frames'), self.all_frames)
+        self.route('GET', (':id', 'frames', 'detector_positions'),
+                   self.detector_positions)
         self.route('GET', (':id', 'scan_positions'), self.scan_positions)
         self.route('POST', (), self.create)
         self.route('DELETE', (':id',), self.delete)
@@ -93,6 +95,14 @@ class StemImage(Resource):
     )
     def all_frames(self, id):
         return self._model.all_frames(id, getCurrentUser())
+
+    @access.user
+    @autoDescribeRoute(
+        Description('Get the detector positions of an image.')
+        .param('id', 'The id of the stem image.')
+    )
+    def detector_positions(self, id):
+        return self._model.detector_positions(id, getCurrentUser())
 
     @access.user
     @autoDescribeRoute(

--- a/girder/stemserver_plugin/stemimage.py
+++ b/girder/stemserver_plugin/stemimage.py
@@ -21,6 +21,8 @@ class StemImage(Resource):
         self.route('GET', (':id', 'dark'), self.dark)
         self.route('GET', (':id', 'bright', 'shape'), self.bright_shape)
         self.route('GET', (':id', 'dark', 'shape'), self.dark_shape)
+        self.route('GET', (':id', 'electron', 'frames'), self.electron_frames)
+        self.route('GET', (':id', 'electron', 'scans'), self.electron_scans)
         self.route('POST', (), self.create)
         self.route('DELETE', (':id',), self.delete)
 
@@ -74,6 +76,22 @@ class StemImage(Resource):
     )
     def dark_shape(self, id):
         return self._model.dark_shape(id, getCurrentUser())
+
+    @access.user
+    @autoDescribeRoute(
+        Description('Get the electron frames of an image.')
+        .param('id', 'The id of the stem image.')
+    )
+    def electron_frames(self, id):
+        return self._model.electron_frames(id, getCurrentUser())
+
+    @access.user
+    @autoDescribeRoute(
+        Description('Get the electron scan positions of an image.')
+        .param('id', 'The id of the stem image.')
+    )
+    def electron_scans(self, id):
+        return self._model.electron_scans(id, getCurrentUser())
 
     @access.user(scope=TokenScope.DATA_WRITE)
     @autoDescribeRoute(

--- a/girder/stemserver_plugin/stemimage.py
+++ b/girder/stemserver_plugin/stemimage.py
@@ -1,11 +1,8 @@
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
-from girder.api.docs import addModel
 from girder.api.rest import Resource
-from girder.api.rest import RestException
 from girder.api.rest import getCurrentUser
 
-from girder.constants import AccessType
 from girder.constants import TokenScope
 
 from .models.stemimage import StemImage as StemImageModel
@@ -84,7 +81,7 @@ class StemImage(Resource):
         .param('id', 'The id of the stem image.')
         .param('scan_position', 'The scan position of the frame.',
                dataType='integer')
-        .errorResponse('Scan position is out of bounds', 400)
+        .errorResponse('Scan position is out of bounds')
     )
     def frame(self, id, scan_position):
         return self._model.frame(id, getCurrentUser(), scan_position)
@@ -113,7 +110,7 @@ class StemImage(Resource):
                    'the image file) or `filePath` (a valid file path on the '
                    'girder server to the image file (admin users only)).',
                    paramType='body')
-        .errorResponse('Failed to create stem image', 400)
+        .errorResponse('Failed to create stem image')
     )
     def create(self, body, params):
         user = self.getCurrentUser()
@@ -122,7 +119,8 @@ class StemImage(Resource):
         file_path = body.get('filePath')
         public = body.get('public', False)
 
-        return self._clean(self._model.create(user, file_id, file_path, public))
+        return self._clean(self._model.create(user, file_id, file_path,
+                                              public))
 
     @access.user(scope=TokenScope.DATA_WRITE)
     @autoDescribeRoute(

--- a/girder/stemserver_plugin/stemimage.py
+++ b/girder/stemserver_plugin/stemimage.py
@@ -18,11 +18,11 @@ class StemImage(Resource):
         self.route('GET', (':id', 'dark'), self.dark)
         self.route('GET', (':id', 'bright', 'shape'), self.bright_shape)
         self.route('GET', (':id', 'dark', 'shape'), self.dark_shape)
-        self.route('GET', (':id', 'frames', ':scan_position'), self.frame)
+        self.route('GET', (':id', 'frames', ':scanPosition'), self.frame)
         self.route('GET', (':id', 'frames'), self.all_frames)
-        self.route('GET', (':id', 'frames', 'detector_positions'),
-                   self.detector_positions)
-        self.route('GET', (':id', 'scan_positions'), self.scan_positions)
+        self.route('GET', (':id', 'frames', 'detectorDimensions'),
+                   self.detector_dimensions)
+        self.route('GET', (':id', 'scanPositions'), self.scan_positions)
         self.route('POST', (), self.create)
         self.route('DELETE', (':id',), self.delete)
 
@@ -98,11 +98,11 @@ class StemImage(Resource):
 
     @access.user
     @autoDescribeRoute(
-        Description('Get the detector positions of an image.')
+        Description('Get the detector dimensions of an image.')
         .param('id', 'The id of the stem image.')
     )
-    def detector_positions(self, id):
-        return self._model.detector_positions(id, getCurrentUser())
+    def detector_dimensions(self, id):
+        return self._model.detector_dimensions(id, getCurrentUser())
 
     @access.user
     @autoDescribeRoute(


### PR DESCRIPTION
Add endpoints to get electron event frames and scan positions.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>