### PR TITLE
Store images created with `filePath` on girder

### DIFF
--- a/girder/stemserver_plugin/models/stemimage.py
+++ b/girder/stemserver_plugin/models/stemimage.py
@@ -24,7 +24,7 @@ class StemImage(AccessControlledModel):
 
     def initialize(self):
         self.name = 'stemimages'
-        self.ensureIndices(('_id', 'fileId'))
+        self.ensureIndices(('fileId',))
         self.exposeFields(level=AccessType.READ, fields=('_id', 'fileId'))
 
     def filter(self, stem_image, user):

--- a/girder/stemserver_plugin/stemimage.py
+++ b/girder/stemserver_plugin/stemimage.py
@@ -81,7 +81,7 @@ class StemImage(Resource):
         .jsonParam('body',
                    'Should contain either `fileId` (a valid girder fileId of '
                    'the image file) or `filePath` (a valid file path on the '
-                   'girder server to the image file).',
+                   'girder server to the image file (admin users only)).',
                    paramType='body')
         .errorResponse('Failed to create stem image', code=400)
     )
@@ -101,11 +101,4 @@ class StemImage(Resource):
         .errorResponse('StemImage not found.', 404)
     )
     def delete(self, id):
-        user = self.getCurrentUser()
-        stem_image = StemImageModel().load(id, user=user,
-                                           level=AccessType.WRITE)
-
-        if not stem_image:
-            raise RestException('StemImage not found.', code=404)
-
-        return StemImageModel().remove(stem_image)
+        return self._model.delete(id, self.getCurrentUser())


### PR DESCRIPTION
Now, if a user creates a stem image with a `filePath` parameter:

1. The user must be an administrator (no one else should be able to read
files on the server).
2. The file is imported to the girder server and put in a private
folder called `stem_images` in the root folder of the user who made it.
If the folder already exists, it will be re-used.
3. The file is put in an item called `_imported_images`. The names of
the files are all just indices (starting with 1). If 1000 files exist,
an error will occur when trying to import another one.
4. When the stem image is deleted, if it was an imported file, the
imported file is deleted as well.

These changes allow us to enforce all stem images to have a girder
`fileId`.

Fixes: #9

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>