### PR TITLE
Generalize data streaming and use in msgpack

### DIFF
--- a/girder/stemserver_plugin/models/stemimage.py
+++ b/girder/stemserver_plugin/models/stemimage.py
@@ -250,7 +250,7 @@ class StemImage(AccessControlledModel):
 
         return _stream
 
-    def _get_dataset_in_chunks(self, dataset, max_chunk_size=1000):
+    def _get_dataset_in_chunks(self, dataset, max_chunk_size=64000):
         """A generator to yield numpy arrays of the dataset.
 
         Args:

--- a/girder/stemserver_plugin/models/stemimage.py
+++ b/girder/stemserver_plugin/models/stemimage.py
@@ -246,7 +246,9 @@ class StemImage(AccessControlledModel):
         def _stream():
             nonlocal f
             with h5py.File(f, 'r') as rf:
-                yield msgpack.packb(rf[path][()].tolist(), use_bin_type=True)
+                dataset = rf[path]
+                for array in self._get_dataset_in_chunks(dataset):
+                    yield msgpack.packb(array.tolist(), use_bin_type=True)
 
         return _stream
 


### PR DESCRIPTION
This allows a max chunk size to be set for sending the arrays
over the network, and calculates a read size based upon that.
However, it will always read at least one array, even if the
max chunk size is exceeded.

This function will hopefully be re-usable by the msgpack format.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>