### PR TITLE
Allow raw data to be read from existing endpoints

### DIFF
--- a/girder/stemserver_plugin/models/stemimage.py
+++ b/girder/stemserver_plugin/models/stemimage.py
@@ -350,5 +350,5 @@ class StemImage(AccessControlledModel):
         if type == 'electron':
             return '/electron_events/frames'
         elif type == 'raw':
-            return '/stem/frames'
+            return '/frames'
         raise RestException('Unknown type: ' + type)

--- a/girder/stemserver_plugin/stemimage.py
+++ b/girder/stemserver_plugin/stemimage.py
@@ -105,9 +105,16 @@ class StemImage(Resource):
         .param('type',
                'The type of data to use. Options: electron (default) or raw',
                default='electron')
+        .param('limit',
+               'Limit the number of diffractograms to prevent timeout',
+               required=False)
+        .param('offset',
+               'Offset to use with the limit',
+               required=False)
     )
-    def all_frames(self, id, type):
-        return self._model.all_frames(id, getCurrentUser(), type)
+    def all_frames(self, id, type, limit, offset):
+        return self._model.all_frames(id, getCurrentUser(), type, limit,
+                                      offset)
 
     @access.user
     @autoDescribeRoute(

--- a/girder/stemserver_plugin/stemimage.py
+++ b/girder/stemserver_plugin/stemimage.py
@@ -89,36 +89,47 @@ class StemImage(Resource):
     @autoDescribeRoute(
         Description('Get a frame of an image.')
         .param('id', 'The id of the stem image.')
-        .param('scan_position', 'The scan position of the frame.',
-               dataType='integer')
+        .param('scanPosition', 'The scan position of the frame.')
+        .param('type',
+               'The type of data to use. Options: electron (default) or raw',
+               default='electron')
         .errorResponse('Scan position is out of bounds')
     )
-    def frame(self, id, scan_position):
-        return self._model.frame(id, getCurrentUser(), scan_position)
+    def frame(self, id, scanPosition, type):
+        return self._model.frame(id, getCurrentUser(), int(scanPosition), type)
 
     @access.user
     @autoDescribeRoute(
         Description('Get all frames of an image (msgpack format only).')
         .param('id', 'The id of the stem image.')
+        .param('type',
+               'The type of data to use. Options: electron (default) or raw',
+               default='electron')
     )
-    def all_frames(self, id):
-        return self._model.all_frames(id, getCurrentUser())
+    def all_frames(self, id, type):
+        return self._model.all_frames(id, getCurrentUser(), type)
 
     @access.user
     @autoDescribeRoute(
         Description('Get the detector dimensions of an image.')
         .param('id', 'The id of the stem image.')
+        .param('type',
+               'The type of data to use. Options: electron (default) or raw',
+               default='electron')
     )
-    def detector_dimensions(self, id):
-        return self._model.detector_dimensions(id, getCurrentUser())
+    def detector_dimensions(self, id, type):
+        return self._model.detector_dimensions(id, getCurrentUser(), type)
 
     @access.user
     @autoDescribeRoute(
         Description('Get the scan positions of an image.')
         .param('id', 'The id of the stem image.')
+        .param('type',
+               'The type of data to use. Options: electron (default) or raw',
+               default='electron')
     )
-    def scan_positions(self, id):
-        return self._model.scan_positions(id, getCurrentUser())
+    def scan_positions(self, id, type):
+        return self._model.scan_positions(id, getCurrentUser(), type)
 
     @access.user(scope=TokenScope.DATA_WRITE)
     @autoDescribeRoute(


### PR DESCRIPTION
This adds a `type` parameter to several endpoints where
a user can specify if they would like to read from electron
counting data or raw data.

Also changed `scan_position` to `scanPosition` because of
an argument error (the argument name must match the name in the
endpoint).

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>