### PR TITLE
Implement read access for GET /stem_images

### DIFF
--- a/girder/stemserver_plugin/models/stemimage.py
+++ b/girder/stemserver_plugin/models/stemimage.py
@@ -31,14 +31,6 @@ class StemImage(AccessControlledModel):
         self.ensureIndices(('fileId',))
         self.exposeFields(level=AccessType.READ, fields=('_id', 'fileId'))
 
-    def filter(self, stem_image, user):
-        stem_image = super(StemImage, self).filter(doc=stem_image, user=user)
-
-        del stem_image['_accessLevel']
-        del stem_image['_modelType']
-
-        return stem_image
-
     def validate(self, doc):
         # Ensure the file exists
         if 'fileId' in doc:

--- a/girder/stemserver_plugin/stemimage.py
+++ b/girder/stemserver_plugin/stemimage.py
@@ -37,10 +37,9 @@ class StemImage(Resource):
         Description('Get stem images')
     )
     def find(self, params):
-        stem_images = self._model.find()
-        # Filter based upon access level.
         user = getCurrentUser()
-        return [self._clean(self._model.filter(x, user)) for x in stem_images]
+        results = self._model.findWithPermissions(user=user)
+        return [self._clean(x) for x in results]
 
     @access.public(scope=TokenScope.DATA_READ)
     @autoDescribeRoute(


### PR DESCRIPTION
As of this commit, GET /stem_images will only return images
for which the user has read access.

The StemImage model filter() function was also removed as
it does not appear to be used nor needed.